### PR TITLE
Add option to exclude empty arrays

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,8 @@ import * as _ from 'lodash';
 
 export default function cleanDeep(object, options) {
   options = _.assign({
-    emptyObjects: true,
     emptyArrays: true,
+    emptyObjects: true,
     emptyStrings: true,
     nullValues: true,
     undefinedValues: true
@@ -30,7 +30,7 @@ export default function cleanDeep(object, options) {
     }
 
     // Exclude empty arrays.
-    if (options.emptyArrays && Array.isArray(value) && _.isEmpty(value)) {
+    if (options.emptyArrays && Array.isArray(value) && !value.length) {
       return;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import * as _ from 'lodash';
 export default function cleanDeep(object, options) {
   options = _.assign({
     emptyObjects: true,
+    emptyArrays: true,
     emptyStrings: true,
     nullValues: true,
     undefinedValues: true
@@ -25,6 +26,11 @@ export default function cleanDeep(object, options) {
 
     // Exclude empty objects.
     if (options.emptyObjects && _.isPlainObject(value) && _.isEmpty(value)) {
+      return;
+    }
+
+    // Exclude empty arrays.
+    if (options.emptyArrays && Array.isArray(value) && _.isEmpty(value)) {
       return;
     }
 

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -13,6 +13,7 @@ describe('cleanDeep()', () => {
   it('should pick defined values from the object', () => {
     const object = {
       bar: {},
+      biz: [],
       foo: {
         bar: undefined,
         baz: true,
@@ -62,6 +63,22 @@ describe('cleanDeep()', () => {
       foo: {
         bar: {}
       }
+    });
+  });
+
+  it('should include empty arrays if `emptyArrays` is `false`', () => {
+    const object = {
+      biz: {
+        baz: 123
+      },
+      foo: []
+    };
+
+    cleanDeep(object, { emptyArrays: false }).should.eql({
+      biz: {
+        baz: 123
+      },
+      foo: []
     });
   });
 


### PR DESCRIPTION
Fixes #3. This changes existing behavior so it should probably be a major version bump:

```sh
npm version major -m "add option to exclude empty arrays"
```