### PR TITLE
Update package.json to reflect MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2015 Seegno
+Copyright (c) 2016 Seegno
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/seegno/clean-deep/issues"
   },
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "options": {
     "changelog": "-o seegno -r clean-deep --only-pulls --use-commit-body --title 'Changelog' --date-format '/ YYYY-MM-DD'",
     "mocha": "--compilers js:babel-core/register --recursive test"


### PR DESCRIPTION
GitHub correctly parses the `LICENSE` file on the root of the project but we should also reflect that on the `package.json`, otherwise `npm` assumes the package is under a non SPDX license. 