### PR TITLE
Update lowest node supported version to 4+

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,4 @@
 {
-  "plugins": [
-    "add-module-exports",
-    "transform-es2015-arrow-functions",
-    "transform-es2015-modules-commonjs",
-    "transform-export-extensions",
-    "transform-strict-mode"
-  ]
+  "presets": ["es2015-node4"],
+  "plugins": ["add-module-exports"]
 }

--- a/package.json
+++ b/package.json
@@ -23,22 +23,22 @@
     "url": "https://github.com/seegno/clean-deep.git"
   },
   "scripts": {
-    "build": "rm -rf dist/* && babel src/ --out-dir dist/",
     "changelog": "github-changes $npm_package_options_changelog",
     "lint": "eslint src test",
-    "test": "NODE_ENV=test mocha $npm_package_options_mocha"
+    "test": "NODE_ENV=test mocha $npm_package_options_mocha",
+    "transpile": "rm -rf dist/* && babel src --out-dir dist"
   },
   "dependencies": {
-    "lodash": "^3.1.0"
+    "lodash.isempty": "^4.4.0",
+    "lodash.isplainobject": "^4.0.6",
+    "lodash.transform": "^4.6.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.1.1",
-    "babel-core": "^6.2.1",
-    "babel-plugin-add-module-exports": "^0.0.4",
-    "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.1.3",
-    "babel-plugin-transform-export-extensions": "^6.1.4",
-    "babel-plugin-transform-strict-mode": "^6.1.4",
+    "babel-cli": "^6.16.0",
+    "babel-core": "^6.16.0",
+    "babel-eslint": "^4.1.3",
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-preset-es2015-node4": "^2.1.0",
     "eslint": "^3.6.1",
     "eslint-config-seegno": "^6.0.0",
     "github-changes": "^1.0.0",
@@ -47,7 +47,7 @@
     "should": "^7.1.1"
   },
   "engines": {
-    "node": ">=5.0.0"
+    "node": ">=4"
   },
   "options": {
     "changelog": "-o seegno -r clean-deep --only-pulls --use-commit-body --title 'Changelog' --date-format '/ YYYY-MM-DD'",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "changelog": "github-changes $npm_package_options_changelog",
     "lint": "eslint src test",
+    "prepublish": "npm run transpile",
     "test": "NODE_ENV=test mocha $npm_package_options_mocha",
     "transpile": "rm -rf dist/* && babel src --out-dir dist"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -3,49 +3,49 @@
  * Module dependencies.
  */
 
-import * as _ from 'lodash';
+import isEmpty from 'lodash.isempty';
+import isPlainObject from 'lodash.isplainobject';
+import transform from 'lodash.transform';
 
 /**
  * Export `cleanDeep` function.
  */
 
-export default function cleanDeep(object, options) {
-  options = _.assign({
-    emptyArrays: true,
-    emptyObjects: true,
-    emptyStrings: true,
-    nullValues: true,
-    undefinedValues: true
-  }, options);
-
-  return _.transform(object, (result, value, key) => {
+export default function cleanDeep(object, {
+  emptyArrays = true,
+  emptyObjects = true,
+  emptyStrings = true,
+  nullValues = true,
+  undefinedValues = true
+} = {}) {
+  return transform(object, (result, value, key) => {
     // Recurse into objects.
-    if (_.isPlainObject(value)) {
-      value = cleanDeep(value, options);
+    if (isPlainObject(value)) {
+      value = cleanDeep(value, { emptyObjects, emptyStrings, nullValues, undefinedValues });
     }
 
     // Exclude empty objects.
-    if (options.emptyObjects && _.isPlainObject(value) && _.isEmpty(value)) {
+    if (emptyObjects && isPlainObject(value) && isEmpty(value)) {
       return;
     }
 
     // Exclude empty arrays.
-    if (options.emptyArrays && Array.isArray(value) && !value.length) {
+    if (emptyArrays && Array.isArray(value) && !value.length) {
       return;
     }
 
     // Exclude empty strings.
-    if (options.emptyStrings && value === '') {
+    if (emptyStrings && value === '') {
       return;
     }
 
     // Exclude null values.
-    if (options.nullValues && _.isNull(value)) {
+    if (nullValues && value === null) {
       return;
     }
 
     // Exclude undefined values.
-    if (options.undefinedValues && _.isUndefined(value)) {
+    if (undefinedValues && value === undefined) {
       return;
     }
 


### PR DESCRIPTION
- Lower the baseline for node support (node 4+).
- Use babel preset instead of individual babel transforms.
- Add transpile script.
- Reduce dependency on the monolithic lodash package.
- Make use of more ES2015 goodies.