### PR TITLE
Fix recursive array cleaning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ export default function cleanDeep(object, {
   return transform(object, (result, value, key) => {
     // Recurse into objects.
     if (isPlainObject(value)) {
-      value = cleanDeep(value, { emptyObjects, emptyStrings, nullValues, undefinedValues });
+      value = cleanDeep(value, { emptyArrays, emptyObjects, emptyStrings, nullValues, undefinedValues });
     }
 
     // Exclude empty objects.

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -71,6 +71,7 @@ describe('cleanDeep()', () => {
   it('should include empty arrays if `emptyArrays` is `false`', () => {
     const object = {
       biz: {
+        bar: [],
         baz: 123
       },
       foo: []
@@ -78,6 +79,7 @@ describe('cleanDeep()', () => {
 
     cleanDeep(object, { emptyArrays: false }).should.eql({
       biz: {
+        bar: [],
         baz: 123
       },
       foo: []


### PR DESCRIPTION
Fixes #15 

The `emptyArrays` option was not being included in the recursive call to `cleanDeep`
