### PR TITLE
Upgrade babel-eslint to avoid 'estraverse-fb' error

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "babel-cli": "^6.16.0",
     "babel-core": "^6.16.0",
-    "babel-eslint": "^4.1.3",
+    "babel-eslint": "^6.1.2",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015-node4": "^2.1.0",
     "eslint": "^3.6.1",


### PR DESCRIPTION
Fixes #16, which unblocks #17.

See https://github.com/babel/babel-eslint/issues/267 for more detail.

cc/ @zeke @ruimarinho