### PR TITLE
Update dist to es5 to keep uglifyjs compatibility

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["es2015-node4"],
+  "presets": ["es2015"],
   "plugins": ["add-module-exports"]
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "babel-core": "^6.16.0",
     "babel-eslint": "^6.1.2",
     "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-preset-es2015-node4": "^2.1.0",
+    "babel-preset-es2015": "^6.22.0",
     "eslint": "^3.6.1",
     "eslint-config-seegno": "^6.0.0",
     "mocha": "^3.1.0",


### PR DESCRIPTION
Hello,

Thanks for this repo. With the actual dist version, it's not possible to uglify this lib. Actually Uglify cannot parse ES6, it will throw you syntax errors like `Unexpected token: name (emptyArrays)`.

Hope it's ok for you !