### PR TITLE
Add the types field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "clean-deep",
   "version": "3.4.0",
   "description": "Remove falsy, empty or nullable values from objects",
+  "types": "./index.d.ts",
   "keywords": [
     "clean",
     "clean-deep",


### PR DESCRIPTION
typescript uses `types` on package.json to load types from a package. Although `index.d.ts` has been part of this project for a few version, typescript still uses any when I import this package.