### PR TITLE
allow numbers as cleanValues

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ export default cleanDeep;
 
 export type CleanOptions = {
     cleanKeys?: string[];
-    cleanValues?: string[];
+    cleanValues?: (string | number)[];
     emptyArrays?: boolean;
     emptyObjects?: boolean;
     emptyStrings?: boolean;


### PR DESCRIPTION
Currently cleanValues only supports strings. In my project I want to remove all `0`(zero) values and this works but Typescript complains. This PR would fix this limitation.